### PR TITLE
Run: Change log level for recipe init error

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -312,7 +312,7 @@ impl<Env> ExecutionTask<Env> where Env: ExecutableDevEnv + Debug {
                             channel,
                             error
                         } => {
-                            info!("[Recipe '{}'] Initialization error for {}: {}", self.script.name, channel, error);
+                            warn!("[Recipe '{}'] Initialization error for {}: {}", self.script.name, channel, error);
                             let _ = on_event.send(ExecutionEvent::ChannelError {
                                 id: channel,
                                 error: error,
@@ -508,4 +508,3 @@ pub enum Error {
     StartStopError(StartStopError),
     APIError(api::Error),
 }
-


### PR DESCRIPTION
I ran into these logs:

```
[2016-04-18 15:58:05.323] (6618) INFO  [Recipe 'Turn off the lights when I leave for work.'] Starting compilation of script.
[2016-04-18 15:58:05.324] (6681) INFO  [Recipe 'Turn off the lights when I leave for work.'] Compilation succeeded.
[2016-04-18 15:58:05.324] (6681) INFO  [Recipe 'Turn off the lights when I leave for work.'] Starting execution of script
[2016-04-18 15:58:05.324] (6681) INFO  [Recipe 'Turn off the lights when I leave for work.'] Initializing rule 0 condition 0. Currently, it can listen to 1 channels.
[2016-04-18 15:58:05.327] (6681) INFO  [Recipe 'Turn off the lights when I leave for work.'] Initializing rule 0 condition 1. Currently, it can listen to 1 channels.
[2016-04-18 15:58:05.327] (6681) INFO  [Recipe 'Turn off the lights when I leave for work.'] Initialization error for getter:power.2.001788fffe243568.philips_hue@link.mozilla.org: Attempting to watch a value from a Channel<Getter> that doesn't support this operation: getter:power.2.001788fffe243568.philips_hue@link.mozilla.org
```

I didn't immediately notice that there was an error hidden in there. Here's a small patch to prevent that from happening again. 

r? @Yoric 